### PR TITLE
CI: add 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 dist: trusty
 cache: bundler
 
@@ -19,6 +18,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby-head
   - ruby-head
   - rbx-3


### PR DESCRIPTION
Add 2.7 to build matrix.

This PR _also_ removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

