### PR TITLE
Use Console logger

### DIFF
--- a/docs/source/Falcon/Capybara/Wrapper/index.html
+++ b/docs/source/Falcon/Capybara/Wrapper/index.html
@@ -83,7 +83,7 @@ end</code></pre>
 		
 		server = Falcon::Server.new(app, endpoint, endpoint.protocol, endpoint.scheme)
 		
-		Async.logger.debug (self) {&quot;Running server...&quot;}
+		Console.logger.debug (self) {&quot;Running server...&quot;}
 		server.run
 	end
 end</code></pre>

--- a/lib/falcon/capybara/wrapper.rb
+++ b/lib/falcon/capybara/wrapper.rb
@@ -58,7 +58,7 @@ module Falcon
 					
 					server = Falcon::Server.new(app, endpoint, protocol: endpoint.protocol, scheme: endpoint.scheme)
 					
-					Async.logger.debug (self) {"Running server..."}
+					Console.logger.debug (self) {"Running server..."}
 					server.run
 				end
 			end


### PR DESCRIPTION
I encountered an exception when loading the test environment for my web app.

```
  0.0s     warn: Async::Task [oid=0xf08c] [ec=0xf0a0] [pid=71094] [2022-10-09 00:00:00 +0000]
               | Task may have ended with unhandled exception.
               |   NoMethodError: undefined method `logger' for Async:Module
               |   
               |   					Async.logger.debug (self) {"Running server..."}
               |   					     ^^^^^^^
               |   → /usr/local/lib/ruby/gems/3.1.0/gems/falcon-capybara-1.5.1/lib/falcon/capybara/wrapper.rb:61 in `block in call'
               |     /usr/local/lib/ruby/gems/3.1.0/gems/async-2.1.0/lib/async/task.rb:107 in `block in run'
               |     /usr/local/lib/ruby/gems/3.1.0/gems/async-2.1.0/lib/async/task.rb:243 in `block in schedule'
```

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
