### PR TITLE
Fix issue where capybara tries to pass an options hash but fails

### DIFF
--- a/lib/falcon/capybara/wrapper.rb
+++ b/lib/falcon/capybara/wrapper.rb
@@ -31,7 +31,7 @@ module Falcon
 			# @parameter port [Integer] The port number to bind to.
 			# @parameter host [String] The local host to bind to.
 			# @parameter options [Hash] Options to pass to the server
-			def call(rack_app, port, host, **options)
+			def call(rack_app, port, host, options = {})
 				require 'async/reactor'
 				require 'falcon/server'
 				

--- a/lib/falcon/capybara/wrapper.rb
+++ b/lib/falcon/capybara/wrapper.rb
@@ -30,7 +30,8 @@ module Falcon
 			# @parameter rack_app [Proc] A Rack application.
 			# @parameter port [Integer] The port number to bind to.
 			# @parameter host [String] The local host to bind to.
-			def call(rack_app, port, host)
+			# @parameter options [Hash] Options to pass to the server
+			def call(rack_app, port, host, **options)
 				require 'async/reactor'
 				require 'falcon/server'
 				


### PR DESCRIPTION
This fixes a problem with this gem that does not provide an argument to receive the options hash sent by Capybara.

Without this you get this error
```
     ArgumentError:
       wrong number of arguments (given 4, expected 3)
     # /usr/local/bundle/bundler/gems/falcon-capybara-9b9c51ec7066/lib/falcon/capybara/wrapper.rb:33:in `call'
     # /usr/local/bundle/bundler/gems/falcon-capybara-9b9c51ec7066/lib/falcon/capybara/servers.rb:14:in `block in <main>'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/config.rb:64:in `block in server='
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/server.rb:77:in `block in boot'
```

Tested against Capybara 3.40.0

Should continue to work against older Capybara that do not demand the argument, and older Ruby that does not demand keywords not be a hash.

Example project testing this: https://github.com/davidsiaw/rails-zen/pull/787

## Types of Changes

- Maintenance.

## Contribution

- [ x ] I tested my changes locally.
- [ x ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
