### PR TITLE
tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,9 @@ jobs:
           - macos
         
         ruby:
-          - "2.7"
-          - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
         
         experimental: [false]
         


### PR DESCRIPTION
I attempted to run down a few versions of ruby and found that at 3.0 it gave me this error:

Fetching gem metadata from https://rubygems.org/........
fiber-local-1.1.0 requires ruby version >= 3.1, which is incompatible with the current version, ruby
3.0.7p220

This tells me that we are no only 3.1 and above? Or perhaps we need to support  a lower version of Ruby by downgrading fiber-local? I'm not sure how to go about this.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.
- Performance improvement.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
