### PR TITLE
attempt to fix tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,9 @@ jobs:
           - macos
         
         ruby:
-          - "2.7"
-          - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
         
         experimental: [false]
         

--- a/falcon-capybara.gemspec
+++ b/falcon-capybara.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 2.5"
 	
-	spec.add_dependency "capybara", "~> 3.37"
-	spec.add_dependency "falcon", "~> 0.34"
+	spec.add_dependency "capybara"
+	spec.add_dependency "falcon"
 	spec.add_dependency "selenium-webdriver"
+	spec.add_dependency "async-io"
 	
 	spec.add_development_dependency "bake"
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"
-	spec.add_development_dependency "rspec", "~> 3.0"
-	spec.add_development_dependency "webdrivers", "~> 4.0"
+	spec.add_development_dependency "rspec"
 end

--- a/falcon-capybara.gemspec
+++ b/falcon-capybara.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "capybara", "~> 3.37"
 	spec.add_dependency "falcon"
 	spec.add_dependency "selenium-webdriver"
-	spec.add_dependency "async-io"
+	spec.add_dependency "io-endpoint"
 	
 	spec.add_development_dependency "bake"
 	spec.add_development_dependency "bundler"

--- a/falcon-capybara.gemspec
+++ b/falcon-capybara.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "capybara", "~> 3.37"
 	spec.add_dependency "falcon"
 	spec.add_dependency "selenium-webdriver"
-	spec.add_dependency "io-endpoint"
 	
 	spec.add_development_dependency "bake"
 	spec.add_development_dependency "bundler"

--- a/falcon-capybara.gemspec
+++ b/falcon-capybara.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
 	
 	spec.files = Dir.glob(['{lib}/**/*', '*.md'], File::FNM_DOTMATCH, base: __dir__)
 	
-	spec.required_ruby_version = ">= 2.5"
+	spec.required_ruby_version = ">= 3.1"
 	
-	spec.add_dependency "capybara"
+	spec.add_dependency "capybara", "~> 3.37"
 	spec.add_dependency "falcon"
 	spec.add_dependency "selenium-webdriver"
 	spec.add_dependency "async-io"

--- a/lib/falcon/capybara/drivers.rb
+++ b/lib/falcon/capybara/drivers.rb
@@ -10,11 +10,12 @@ require 'capybara'
 # @name selenium_chrome_https
 # @attribute [Block]
 Capybara.register_driver :selenium_chrome_https do |app|
-	require 'selenium/webdriver'
-	
-	Capybara.drivers[:selenium_chrome].call(app).tap do |driver|
-		driver.options[:capabilities].args << '--allow-insecure-localhost'
-	end
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options.add_argument('--allow-insecure-localhost')
+  chrome_options.add_argument('--ignore-certificate-errors')
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 options: chrome_options)
 end
 
 # A headless selenium driver for chrome which allows insecure localhost https protocol.
@@ -22,9 +23,11 @@ end
 # @name selenium_chrome_headless_https
 # @attribute [Block]
 Capybara.register_driver :selenium_chrome_headless_https do |app|
-	require 'selenium/webdriver'
-	
-	Capybara.drivers[:selenium_chrome_headless].call(app).tap do |driver|
-		driver.options[:capabilities].args << '--allow-insecure-localhost'
-	end
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options.add_argument('--allow-insecure-localhost')
+  chrome_options.add_argument('--ignore-certificate-errors')
+  chrome_options.add_argument('--headless=true')
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 options: chrome_options)
 end

--- a/lib/falcon/capybara/wrapper.rb
+++ b/lib/falcon/capybara/wrapper.rb
@@ -9,7 +9,7 @@ require 'thread'
 
 require 'async'
 require 'falcon/endpoint'
-require 'async/io/notification'
+require 'io/endpoint'
 
 module Falcon
 	module Capybara

--- a/lib/falcon/capybara/wrapper.rb
+++ b/lib/falcon/capybara/wrapper.rb
@@ -9,7 +9,6 @@ require 'thread'
 
 require 'async'
 require 'falcon/endpoint'
-require 'io/endpoint'
 
 module Falcon
 	module Capybara

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'capybara'
 
 require "falcon/capybara"
 
-require "webdrivers"
 require "selenium/webdriver"
 
 require "capybara/rspec"


### PR DESCRIPTION
This PR attempts to fix the tests to get them to a working state again.

Changes are:
- comply with new capybara driver syntax
- remove webdriver gem interfering with chrome download
- add required async-io gem (probably should be pulled in by falcon?)
- update ruby min version and removed other gem version restrictions.

## Types of Changes

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
